### PR TITLE
Fix #18 Remove timeSpent from all day events + UX tweaks

### DIFF
--- a/Morty/Managers/EventsManager.swift
+++ b/Morty/Managers/EventsManager.swift
@@ -94,15 +94,7 @@ class EventsManager {
     }
 
     func updateDayEvents() {
-        let rawEvents = fetchEvents()
-            .map {
-                Event.init(
-                    startDate: $0.startDate,
-                    endDate: $0.endDate,
-                    title: $0.title,
-                    type: .meeting
-                )
-            }
+        let rawEvents = fetchEvents().map { Event(from: $0) }
 
         // Remove duplicates
         let events = Array(Set(rawEvents))

--- a/Morty/MenuView/MenuDayView.swift
+++ b/Morty/MenuView/MenuDayView.swift
@@ -77,6 +77,12 @@ class MenuDayView: NSView {
         case .someEvents(let events, let timeSpent):
             // events views and at the end a summary about how many hours we have spent
             var eventViews = views(from: events)
+
+            // if the events don't add time spent, then avoid the summaryView
+            guard timeSpent > 0 else {
+                return eventViews
+            }
+
             let label = "\(MenuDayViewModel.timeSpentFormatted(from: timeSpent)) spent in meetings."
             eventViews.append(summaryView(from: label))
             return eventViews

--- a/Morty/MenuView/MenuDayViewModel.swift
+++ b/Morty/MenuView/MenuDayViewModel.swift
@@ -66,6 +66,8 @@ class MenuDayViewModel {
         }
 
         let timeSpent = events
+            // allDay events should be ignored
+            .filter { $0.type == .meeting }
             .compactMap { $0.endDate.timeIntervalSince($0.startDate) }
             .reduce(0, { $0 + $1 })
 
@@ -100,8 +102,10 @@ class MenuDayViewModel {
                 .map { $0.standupText }
                 .joined(separator: "\n")
 
-            let timeSpentString = String(format: "\n\n🕓 %.2f hours spent in meetings", timeSpent)
-            text.append(contentsOf: timeSpentString)
+            if timeSpent > 0 {
+                let timeSpentString = String(format: "\n\n🕓 %.2f hours spent in meetings", timeSpent)
+                text.append(contentsOf: timeSpentString)
+            }
 
             let pasteboard = NSPasteboard.general
             pasteboard.declareTypes([.string], owner: nil)


### PR DESCRIPTION
![Screen Shot 2021-11-07 at 19 50 37](https://user-images.githubusercontent.com/681600/140664800-aaf80371-6539-4b72-af89-af7342f76d1d.png)

- [x] Using a calendar emoji symbol instead of a telephone (on menu + clipboard)
- [x] All day events should not add time in time spent 